### PR TITLE
Bump up mockito core version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-    compile 'org.mockito:mockito-core:2.0.44-beta'
+    compile 'org.mockito:mockito-core:2.0.111-beta'
 
     testCompile 'junit:junit:4.12'
 }

--- a/src/main/kotlin/com/sys1yagi/kmockito/mockito_extensions.kt
+++ b/src/main/kotlin/com/sys1yagi/kmockito/mockito_extensions.kt
@@ -66,12 +66,12 @@ private fun <T> Class<T>.defaultMock(): T {
     val mockSettingsImpl = MockSettingsImpl<T>()
     mockSettingsImpl.defaultAnswer(Answers.RETURNS_DEFAULTS)
     val mockCreationSettings = mockSettingsImpl.confirm(this)
-    return MockUtil().createMock(mockCreationSettings)
+    return MockUtil.createMock(mockCreationSettings)
 }
 
 // answer
 
-inline fun <reified T : Any> InvocationOnMock.getArgumentAt(index: Int): T = getArgumentAt(index, T::class.java)
+inline fun <reified T : Any> InvocationOnMock.getArgumentAt(index: Int): T = getArgument(index)
 inline fun <reified A> InvocationOnMock.arguments(): A = arguments[0] as A
 inline fun <reified A, reified B> InvocationOnMock.arguments2() = Pair(arguments[0] as A, arguments[1] as B)
 inline fun <reified A, reified B, reified C> InvocationOnMock.arguments3() = Triple(arguments[0] as A, arguments[1] as B, arguments[2] as C)


### PR DESCRIPTION
Bump up mockito core version to 2.0.111-beta.

And adapt to below mockito's api changes.
- [Remove getArgumentAt](https://github.com/mockito/mockito/commit/dff5510cb3e97dae414e58ba85825ad01b273c72) inclueded from v2.0.54-beta
- [Modified MockUtil to static util class](https://github.com/mockito/mockito/commit/3fe3b62d2bc5ac60bb85c4bed8870f51109d167c) inclueded from 2.0.94-beta
